### PR TITLE
Improve cargo compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "drop_backend"
 version = "0.1.0"
-edition = "2025"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
## Summary
- update to a supported Rust edition

## Testing
- `cargo check --locked --offline` *(fails: no matching package named `actix-web` found)*

------
https://chatgpt.com/codex/tasks/task_e_6854dc94fdd8832fa25141731eb57fab